### PR TITLE
fix(.goreleaser.yaml): set signs and docker_sign cosign non-interactive

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,3 +89,5 @@ docker_signs:
     args:
     - 'sign'
     - '${artifact}'
+    - "--yes" # needed on cosign 2.0.0+
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,7 @@ signs:
     - '--output-certificate=${certificate}'
     - '--output-signature=${signature}'
     - '${artifact}'
+    - "--yes" # needed on cosign 2.0.0+
   artifacts: checksum
   output: true
 


### PR DESCRIPTION
Fixes #39 